### PR TITLE
Correct casing of IPython

### DIFF
--- a/src/templates/index.jade
+++ b/src/templates/index.jade
@@ -94,10 +94,10 @@ block content
                 .column-4
                     .feature-callout
                         .callout
-                            | iPython Support
+                            | IPython Support
                         img(src="/images/icons/ipython.svg")
                         .description
-                            | Experience the full power of interactive visualizations inside of the iPython notebook. 
+                            | Experience the full power of interactive visualizations inside of the IPython notebook. 
                             a(href="http://nbviewer.ipython.org/github/lightning-viz/lightning-example-notebooks/blob/master/plots/scatter.ipynb")
                                 | Click here to see a demo.
 


### PR DESCRIPTION
Note that nbviewer.ipython.org seem to be down now, (we might have make a mistake in migrating DNS at nbviewer.jupyter.org and leaving the nbviewer.ipython.org alias) but I'll investigate.
