### PR TITLE
update devDependencies to work with newer node.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,30 +42,31 @@
   },
   "scripts": {
     "deploy": "./build.sh",
-    "build": "gulp build"
+    "build": "gulp build",
+    "gulp": "gulp"
   },
   "devDependencies": {
-    "browserify": "~4.1.8",
-    "colors": "~0.6.2",
-    "express": "~4.0.0",
-    "gulp": "~3.8.0",
+    "browserify": "~13.1.0",
+    "colors": "~1.1.2",
+    "express": "~4.14.0",
+    "gulp": "~3.9.1",
     "gulp-browserify": "~0.5.0",
     "gulp-buster": "git://github.com/mathisonian/gulp-buster",
-    "gulp-csso": "~0.2.7",
-    "gulp-gzip": "0.0.6",
-    "gulp-if": "0.0.5",
-    "gulp-jade": "~0.5.0",
-    "gulp-livereload": "~1.3.1",
+    "gulp-csso": "~2.0.0",
+    "gulp-gzip": "1.4.0",
+    "gulp-if": "2.0.1",
+    "gulp-jade": "~1.1.0",
+    "gulp-livereload": "~3.8.1",
     "gulp-rename": "~1.2.0",
     "gulp-s3": "git://github.com/mathisonian/gulp-s3",
-    "gulp-sass": "~0.7.1",
+    "gulp-sass": "~2.3.2",
     "gulp-tap": "^0.1.3",
-    "gulp-uglify": "~0.2.1",
-    "gulp-util": "~2.2.14",
-    "jade": "~1.3.1",
-    "jadeify": "~2.3.0",
-    "path": "~0.4.9",
-    "tiny-lr": "0.0.5"
+    "gulp-uglify": "~2.0.0",
+    "gulp-util": "~3.0.7",
+    "jade": "~1.11.0",
+    "jadeify": "~4.6.0",
+    "path": "~0.12.7",
+    "tiny-lr": "0.2.1"
   },
   "engines": {
     "node": ">=0.8.0"


### PR DESCRIPTION
Updates the dev deps to make development with newer node.js work. older gulp-sass/node-sass threw an error.
